### PR TITLE
fix: add missing links from AllForOne and remove duplicates

### DIFF
--- a/.cent.yaml
+++ b/.cent.yaml
@@ -11,45 +11,42 @@ exclude-files:
 
 # Add github urls
 community-templates:
+  - https://gist.github.com/0x240x23elu
+  - https://gist.github.com/ResistanceIsUseless/e46848f67706a8aa1205c9d2866bff31
   - https://github.com/0x727/ObserverWard
+  - https://github.com/0x727/ObserverWard_0x727
   - https://github.com/0xAwali/Blind-SSRF
   - https://github.com/0xAwali/Virtual-Host
-  - https://github.com/0xPugazh/my-nuclei-templates
+  - https://github.com/0xKayala/Custom-Nuclei-Templates
   - https://github.com/0xmaximus/final_freaking_nuclei_templates
+  - https://github.com/0XParthJ/Nuclei-Templates
+  - https://github.com/0xPugazh/my-nuclei-templates
+  - https://github.com/0xSojalSec/kenzer-templates
+  - https://github.com/0xSojalSec/my-nuclei-templates-1
+  - https://github.com/0xSojalSec/nuclei-templates-4
+  - https://github.com/0xSojalSec/nuclei-templates-5
+  - https://github.com/0xSojalSec/Nuclei-Templates-API-Linkfinder
+  - https://github.com/0xSojalSec/Nuclei-Templates-Collection
+  - https://github.com/0xSojalSec/Nuclei-TemplatesNuclei-Templates-CVE-2017-17736
+  - https://github.com/0xSojalSec/nuclei_templates-SymfonyRCE
+  - https://github.com/0xSojalSec/nuclei-templates-websphere-portal-preauth-ssrf
+  - https://github.com/0xSojalSec/templatesallnuclei
+  - https://github.com/0xSojalSec/templates-nuclei-Oracle-OAM---XSS
+  - https://github.com/1dayluo/My-Nuclei-Templates
   - https://github.com/1in9e/my-nuclei-templates
-  - https://github.com/ARPSyndicate/kenzer-templates
-  - https://github.com/Akokonunes/Private-Nuclei-Templates
-  - https://github.com/Arvinthksrct/alltemplate
-  - https://github.com/AshiqurEmon/nuclei_templates
-  - https://github.com/CharanRayudu/Custom-Nuclei-Templates
-  - https://github.com/DoubleTakes/nuclei-templates
-  - https://github.com/Elsfa7-110/mynuclei-templates
-  - https://github.com/ExpLangcn/NucleiTP
-  - https://github.com/Harish4948/Nuclei-Templates
-  - https://github.com/Hunt2behunter/nuclei-templates
-  - https://github.com/Jagomeiister/nuclei-templates
-  - https://github.com/JoshMorrison99/url-based-nuclei-templates
-  - https://github.com/Kaue-Navarro/Templates-kaue-nuclei
-  - https://github.com/KeepHowling/all_freaking_nuclei_templates
-  - https://github.com/Lopseg/nuclei-c-templates
-  - https://github.com/Lu3ky13/Authorization-Nuclei-Templates
-  - https://github.com/MR-pentestGuy/nuclei-templates
-  - https://github.com/NightRang3r/misc_nuclei_templates
-  - https://github.com/NitinYadav00/My-Nuclei-Templates
-  - https://github.com/Odayex/Random-Nuclei-Templates
-  - https://github.com/PedroF-369/nuclei_templates
-  - https://github.com/R-s0n/Custom_Vuln_Scan_Templates
-  - https://github.com/Saimonkabir/Nuclei-Templates
-  - https://github.com/Saptak9983/Nuclei-Template
-  - https://github.com/SirAppSec/nuclei-template-generator-log4j
-  - https://github.com/SirBugs/Priv8-Nuclei-Templates
-  - https://github.com/Str1am/my-nuclei-templates
-  - https://github.com/SumedhDawadi/Custom-Nuclei-Template
-  - https://github.com/System00-Security/backflow
+  - https://github.com/5cr1pt/templates
+  - https://github.com/abbycantcode/Nuclei-Template
   - https://github.com/adampielak/nuclei-templates
   - https://github.com/aels/CVE-2022-37042
+  - https://github.com/Aituglo/nuclei-templates
+  - https://github.com/Akokonunes/Private-Nuclei-Templates
   - https://github.com/alexrydzak/rydzak-nuclei-templates
+  - https://github.com/ARPSyndicate/kenzer-templates
+  - https://github.com/Arvinthksrct/alltemplate
+  - https://github.com/AshiqurEmon/nuclei_templates
+  - https://github.com/AshiqurEmon/nuclei_templates.git
   - https://github.com/ayadim/Nuclei-bug-hunter
+  - https://github.com/b4dboy17/badboy_17-Nuclei-Templates-Collection
   - https://github.com/badboy-sft/badboy_17-Nuclei-Templates-Collection
   - https://github.com/bhataasim1/PersonalTemplates
   - https://github.com/binod235/nuclei-templates-and-reports
@@ -57,194 +54,140 @@ community-templates:
   - https://github.com/boobooHQ/private_templates
   - https://github.com/brinhosa/brinhosa-nuclei-templates
   - https://github.com/bug-vs-me/nuclei
-  - https://github.com/c-sh0/nuclei_templates
+  - https://github.com/CharanRayudu/Custom-Nuclei-Templates
+  - https://github.com/ChiaraNRTT96/BountySkill
   - https://github.com/cipher387/juicyinfo-nuclei-templates
   - https://github.com/clarkvoss/Nuclei-Templates
   - https://github.com/coldrainh/nuclei-ByMyself
+  - https://github.com/c-sh0/nuclei_templates
   - https://github.com/d3sca/Nuclei_Templates
   - https://github.com/daffainfo/my-nuclei-templates
+  - https://github.com/Dalaho-bangin/my_nuclei_templates
   - https://github.com/damon-sec/Nuclei-templates-Collection
+  - https://github.com/davidfortytwo/GetNucleiTemplates
   - https://github.com/dk4trin/templates-nuclei
+  - https://github.com/DoubleTakes/nuclei-templates
+  - https://github.com/drfabiocastro/certwatcher-templates
+  - https://github.com/edoardottt/missing-cve-nuclei-templates
+  - https://github.com/ed-red/redmc_custom_templates_nuclei
   - https://github.com/ekinsb/Nuclei-Templates
+  - https://github.com/Elsfa7-110/mynuclei-templates
   - https://github.com/erickfernandox/nuclei-templates
   - https://github.com/esetal/nuclei-bb-templates
   - https://github.com/ethicalhackingplayground/erebus-templates
+  - https://github.com/Excis3/bans4-nuclei
+  - https://github.com/ExpLangcn/NucleiTP
+  - https://github.com/foulenzer/foulenzer-templates
   - https://github.com/freakyclown/Nuclei_templates
   - https://github.com/geeknik/nuclei-templates-1
   - https://github.com/geeknik/the-nuclei-templates
   - https://github.com/glyptho/templatesallnuclei
+  - https://github.com/h0tak88r/nuclei_templates
+  - https://github.com/h4ndsh/nuclei-templates
+  - https://github.com/Harish4948/Nuclei-Templates
+  - https://github.com/Hunt2behunter/nuclei-templates
   - https://github.com/im403/nuclei-temp
+  - https://github.com/imhunterand/nuclei-custom-templates
+  - https://github.com/Jagomeiister/nuclei-templates
   - https://github.com/javaongsan/nuclei-templates
+  - https://github.com/joanbono/nuclei-templates
+  - https://github.com/JoshMorrison99/url-based-nuclei-templates
   - https://github.com/justmumu/SpringShell
   - https://github.com/kabilan1290/templates
+  - https://github.com/Kaue-Navarro/Templates-kaue-nuclei
+  - https://github.com/KeepHowling/all_freaking_nuclei_templates
   - https://github.com/kh4sh3i/CVE-2022-23131
+  - https://github.com/kh4sh3i/nuclei-templates
+  - https://github.com/Linuxinet/mobile-nuclei-templates
+  - https://github.com/Linuxinet/nuclei-templates
+  - https://github.com/Lopseg/nuclei-c-templates
+  - https://github.com/Lu3ky13/Authorization-Nuclei-Templates
   - https://github.com/luck-ying/Library-YAML-POC
   - https://github.com/mastersir-lab/nuclei-yaml-poc
   - https://github.com/mbskter/Masscan2Httpx2Nuclei-Xray
   - https://github.com/medbsq/ncl
   - https://github.com/meme-lord/Custom-Nuclei-Templates
+  - https://github.com/microphone-mathematics/custom-nuclei-templates
+  - https://github.com/mosesrenegade/nuclei-templates
+  - https://github.com/MR-pentestGuy/nuclei-templates
   - https://github.com/n1f2c3/mytemplates
+  - https://github.com/NightRang3r/misc_nuclei_templates
+  - https://github.com/Nithissh0708/Custom-Nuclei-Templates
+  - https://github.com/NitinYadav00/My-Nuclei-Templates
   - https://github.com/notnotnotveg/nuclei-custom-templates
+  - https://github.com/nvsecurity/nightvision-nuclei-templates
   - https://github.com/obreinx/nuceli-templates
+  - https://github.com/Odayex/Random-Nuclei-Templates
   - https://github.com/optiv/mobile-nuclei-templates
+  - https://github.com/p0ch4t/nuclei-special-templates
+  - https://github.com/pacho15/mynuclei_templates
   - https://github.com/panch0r3d/nuclei-templates
+  - https://github.com/pdelteil/BugBountyReportTemplates
   - https://github.com/peanuth8r/Nuclei_Templates
+  - https://github.com/PedroF-369/nuclei_templates
+  - https://github.com/PedroFerreira97/nuclei_templates
   - https://github.com/pentest-dev/Profesional-Nuclei-Templates
   - https://github.com/pikpikcu/my-nuclei-templates
+  - https://github.com/pikpikcu/nuclei-fuzz
   - https://github.com/pikpikcu/nuclei-templates
   - https://github.com/ping-0day/templates
   - https://github.com/praetorian-inc/chariot-launch-nuclei-templates
+  - https://github.com/projectdiscovery/fuzzing-templates
   - https://github.com/projectdiscovery/nuclei-templates
-  - https://github.com/ptyspawnbinbash/template-enhancer
-  - https://github.com/rafaelcaria/Nuclei-Templates
-  - https://github.com/rafaelwdornelas/my-nuclei-templates
-  - https://github.com/rahulkadavil/nuclei-templates
-  - https://github.com/randomstr1ng/nuclei-sap-templates
-  - https://github.com/redteambrasil/nuclei-templates
-  - https://github.com/ree4pwn/my-nuclei-templates
-  - https://github.com/ricardomaia/nuclei-template-generator-for-wordpress-plugins
-  - https://github.com/rix4uni/BugBountyTips
-  - https://github.com/sadnansakin/my-nuclei-templates
-  - https://github.com/securitytest3r/nuclei_templates_work
-  - https://github.com/sharathkramadas/k8s-nuclei-templates
-  - https://github.com/shifa123/detections
-  - https://github.com/sl4x0/NC-Templates
-  - https://github.com/smaranchand/nuclei-templates
-  - https://github.com/soumya123raj/Nuclei
-  - https://github.com/tamimhasan404/Open-Source-Nuclei-Templates-Downloader
-  - https://github.com/test502git/log4j-fuzz-head-poc
-  - https://github.com/th3r4id/nuclei-templates
-  - https://github.com/thebrnwal/Content-Injection-Nuclei-Script
-  - https://github.com/thecyberneh/nuclei-templatess
-  - https://github.com/thelabda/nuclei-templates
-  - https://github.com/topscoder/nuclei-wordfence-cve
-  - https://github.com/toramanemre/apache-solr-log4j-CVE-2021-44228
-  - https://github.com/toramanemre/log4j-rce-detect-waf-bypass
-  - https://github.com/trickest/log4j
-  - https://github.com/wasp76b/nuclei-templates
-  - https://github.com/wr00t/templates
-  - https://github.com/xinZa1/template
-  - https://github.com/yarovit-developer/nuclei-templates
-  - https://github.com/yavolo/nuclei-templates
-  - https://github.com/z3bd/nuclei-templates
-  - https://github.com/zer0yu/Open-PoC
-  - https://gist.github.com/0x240x23elu
-  - https://gist.github.com/ResistanceIsUseless/e46848f67706a8aa1205c9d2866bff31
-  - https://github.com/0XParthJ/Nuclei-Templates
-  - https://github.com/0x727/ObserverWard_0x727
-  - https://github.com/0xAwali/Virtual-Host
-  - https://github.com/0xKayala/Custom-Nuclei-Templates
-  - https://github.com/0xPugazh/my-nuclei-templates
-  - https://github.com/0xmaximus/final_freaking_nuclei_templates
-  - https://github.com/1in9e/my-nuclei-templates
-  - https://github.com/5cr1pt/templates
-  - https://github.com/Akokonunes/Private-Nuclei-Templates
-  - https://github.com/Arvinthksrct/alltemplate
-  - https://github.com/AshiqurEmon/nuclei_templates.git
-  - https://github.com/Dalaho-bangin/my_nuclei_templates
-  - https://github.com/DoubleTakes/nuclei-templates
-  - https://github.com/Elsfa7-110/mynuclei-templates
-  - https://github.com/Excis3/bans4-nuclei
-  - https://github.com/ExpLangcn/NucleiTP
-  - https://github.com/Harish4948/Nuclei-Templates
-  - https://github.com/Hunt2behunter/nuclei-templates
-  - https://github.com/Jagomeiister/nuclei-templates
-  - https://github.com/JoshMorrison99/url-based-nuclei-templates
-  - https://github.com/Kaue-Navarro/Templates-kaue-nuclei
-  - https://github.com/KeepHowling/all_freaking_nuclei_templates
-  - https://github.com/Linuxinet/nuclei-templates
-  - https://github.com/Lopseg/nuclei-c-templates
-  - https://github.com/MR-pentestGuy/nuclei-templates
-  - https://github.com/NightRang3r/misc_nuclei_templates
-  - https://github.com/NitinYadav00/My-Nuclei-Templates
-  - https://github.com/Odayex/Random-Nuclei-Templates
-  - https://github.com/PedroFerreira97/nuclei_templates
-  - https://github.com/R-s0n/Custom_Vuln_Scan_Templates
-  - https://github.com/RandomRobbieBF/nuclei-drupal-sa
-  - https://github.com/Red-Darkin/Custom-Nuclei-Templates
-  - https://github.com/Saimonkabir/Nuclei-Templates
-  - https://github.com/Saptak9983/Nuclei-Template
-  - https://github.com/SirAppSec/nuclei-template-generator-log4j
-  - https://github.com/SirBugs/Priv8-Nuclei-Templates
-  - https://github.com/Str1am/my-nuclei-templates
-  - https://github.com/SumedhDawadi/Custom-Nuclei-Template
-  - https://github.com/U53RW4R3/nuclei-fuzzer-templates
-  - https://github.com/UltimateSec/ultimaste-nuclei-templates
-  - https://github.com/VulnExpo/nuclei-templates
-  - https://github.com/adampielak/nuclei-templates
-  - https://github.com/aels/CVE-2022-37042
-  - https://github.com/alexrydzak/rydzak-nuclei-templates
-  - https://github.com/ayadim/Nuclei-bug-hunter
-  - https://github.com/badboy-sft/badboy_17-Nuclei-Templates-Collection
-  - https://github.com/bhataasim1/PersonalTemplates
-  - https://github.com/binod235/nuclei-templates-and-reports
-  - https://github.com/blazeinfosec/nuclei-templates
-  - https://github.com/brinhosa/brinhosa-nuclei-templates
-  - https://github.com/c-sh0/nuclei_templates
-  - https://github.com/cipher387/juicyinfo-nuclei-templates
-  - https://github.com/clarkvoss/Nuclei-Templates
-  - https://github.com/coldrainh/nuclei-ByMyself
-  - https://github.com/d3sca/Nuclei_Templates
-  - https://github.com/daffainfo/my-nuclei-templates
-  - https://github.com/damon-sec/Nuclei-templates-Collection
-  - https://github.com/davidfortytwo/GetNucleiTemplates
-  - https://github.com/dk4trin/templates-nuclei
-  - https://github.com/ed-red/redmc_custom_templates_nuclei
-  - https://github.com/edoardottt/missing-cve-nuclei-templates
-  - https://github.com/ekinsb/Nuclei-Templates
-  - https://github.com/erickfernandox/nuclei-templates
-  - https://github.com/esetal/nuclei-bb-templates
-  - https://github.com/ethicalhackingplayground/erebus-templates
-  - https://github.com/glyptho/templatesallnuclei
-  - https://github.com/h0tak88r/nuclei_templates
-  - https://github.com/h4ndsh/nuclei-templates
-  - https://github.com/imhunterand/nuclei-custom-templates
-  - https://github.com/javaongsan/nuclei-templates
-  - https://github.com/justmumu/SpringShell
-  - https://github.com/kabilan1290/templates
-  - https://github.com/kh4sh3i/CVE-2022-23131
-  - https://github.com/luck-ying/Library-YAML-POC
-  - https://github.com/mastersir-lab/nuclei-yaml-poc
-  - https://github.com/mbskter/Masscan2Httpx2Nuclei-Xray
-  - https://github.com/meme-lord/Custom-Nuclei-Templates
-  - https://github.com/microphone-mathematics/custom-nuclei-templates
-  - https://github.com/n1f2c3/mytemplates
-  - https://github.com/notnotnotveg/nuclei-custom-templates
-  - https://github.com/nvsecurity/nightvision-nuclei-templates
-  - https://github.com/panch0r3d/nuclei-templates
-  - https://github.com/pentest-dev/Profesional-Nuclei-Templates
-  - https://github.com/pikpikcu/nuclei-fuzz
-  - https://github.com/ping-0day/templates
-  - https://github.com/praetorian-inc/chariot-launch-nuclei-templates
   - https://github.com/ptyspawnbinbash/template-enhancer
   - https://github.com/r3dcl1ff/Symfony-Fuck
   - https://github.com/rafaelcaria/Nuclei-Templates
   - https://github.com/rafaelwdornelas/my-nuclei-templates
   - https://github.com/rahulkadavil/nuclei-templates
+  - https://github.com/RandomRobbieBF/nuclei-drupal-sa
+  - https://github.com/randomstr1ng/nuclei-sap-templates
+  - https://github.com/Red-Darkin/Custom-Nuclei-Templates
   - https://github.com/redteambrasil/nuclei-templates
+  - https://github.com/ree4pwn/my-nuclei-templates
   - https://github.com/reewardius/log4shell-templates
   - https://github.com/ricardomaia/nuclei-template-generator-for-wordpress-plugins
+  - https://github.com/rix4uni/BugBountyTips
+  - https://github.com/R-s0n/Custom_Vuln_Scan_Templates
   - https://github.com/sadnansakin/my-nuclei-templates
+  - https://github.com/Saimonkabir/Nuclei-Templates
+  - https://github.com/Saptak9983/Nuclei-Template
   - https://github.com/securitytest3r/nuclei_templates_work
+  - https://github.com/ShangRui-hash/my-nuclei-templates
   - https://github.com/sharathkramadas/k8s-nuclei-templates
   - https://github.com/shifa123/detections
+  - https://github.com/SirAppSec/nuclei-template-generator-log4j
+  - https://github.com/SirBugs/Priv8-Nuclei-Templates
   - https://github.com/sl4x0/NC-Templates
   - https://github.com/smaranchand/nuclei-templates
+  - https://github.com/soapffz/myown-nuclei-poc
   - https://github.com/solo10010/solo-nuclei-templates
   - https://github.com/soumya123raj/Nuclei
+  - https://github.com/souzomain/mytemplates
   - https://github.com/srkgupta/cent-nuclei-templates
+  - https://github.com/Str1am/my-nuclei-templates
+  - https://github.com/SumedhDawadi/Custom-Nuclei-Template
+  - https://github.com/System00-Security/backflow
   - https://github.com/tamimhasan404/Open-Source-Nuclei-Templates-Downloader
   - https://github.com/test502git/log4j-fuzz-head-poc
   - https://github.com/th3r4id/nuclei-templates
   - https://github.com/thanhnx9/nuclei-templates-cutomer
+  - https://github.com/thebrnwal/Content-Injection-Nuclei-Script
   - https://github.com/thecyberneh/nuclei-templatess
+  - https://github.com/thelabda/labdanuclei
   - https://github.com/thelabda/nuclei-templates
-  - https://github.com/themoonbaba/private_templates/blob/main/springboot_heapdump.yaml
+  - https://github.com/themastersunil/nucleiDB
+  - https://github.com/themastersunil/Nuclei-TamplatesBackup
+  - https://github.com/themoonbaba/private_templates
+  - https://github.com/topscoder/nuclei-wordfence-cve
   - https://github.com/toramanemre/apache-solr-log4j-CVE-2021-44228
   - https://github.com/toramanemre/log4j-rce-detect-waf-bypass
   - https://github.com/trickest/log4j
+  - https://github.com/trungkay2/Nuclei-template
+  - https://github.com/U53RW4R3/nuclei-fuzzer-templates
+  - https://github.com/UltimateSec/ultimaste-nuclei-templates
   - https://github.com/v3l4r10/Nuclei-Templates
   - https://github.com/valaDevs/nuclei-backupfile-finder
+  - https://github.com/VulnExpo/nuclei-templates
   - https://github.com/vulnspace/nuclei-templates
   - https://github.com/wasp76b/nuclei-templates
   - https://github.com/wearetyomsmnv/llm_integrated_nuclei_templates
@@ -255,3 +198,4 @@ community-templates:
   - https://github.com/z3bd/nuclei-templates
   - https://github.com/zer0yu/Open-PoC
   - https://github.com/zerbaliy3v/custom-nuclei-templates
+  - https://github.com/zinminphyo0/KozinTemplates


### PR DESCRIPTION
The goal of this PR is to improve the default template links in [.cent.yaml](https://github.com/xm1k3/cent/blob/main/.cent.yaml).

Missing links from the [AllForOne project](https://github.com/AggressiveUser/AllForOne/blob/main/PleaseUpdateMe.txt) were added, duplicates removed and the list sorted alphabetically.

The original list contained 244 URLs, with several duplicates. The new combined list contains 188 URLs.